### PR TITLE
Frame Buffer and Vertex Data Alignment

### DIFF
--- a/src/framebuffer.sv
+++ b/src/framebuffer.sv
@@ -18,7 +18,7 @@ module framebuffer #(
 
     // output to the memory interconnect (as a master)
     output logic o_mem_req,
-    output logic [$clog2(SCREEN_WIDTH*SCREEN_HEIGHT)-1:0] o_mem_addr,
+    output logic [($clog2(SCREEN_WIDTH*SCREEN_HEIGHT)+7)/8*8-1:0] o_mem_addr, // Padded to the next byte size for alignment
     output logic [COLOR_WIDTH-1:0] o_mem_wdata
 );
 
@@ -30,7 +30,7 @@ module framebuffer #(
   // drives the memory request bus directly
   // asserts a one-cycle request whenever a valid pixel arrives from the fragment shader
   assign o_mem_req   = i_pixel_we;
-  assign o_mem_addr  = write_addr;
+  assign o_mem_addr = {write_addr, { ((($clog2(SCREEN_WIDTH*SCREEN_HEIGHT)+7)/8*8)-$clog2(SCREEN_WIDTH*SCREEN_HEIGHT)){1'b0} } }; // Pads this on the LSB to the next byte for alignment
   assign o_mem_wdata = i_pixel_color;
 
 endmodule

--- a/src/gpu_top.sv
+++ b/src/gpu_top.sv
@@ -29,7 +29,9 @@ module gpu_top #(
   localparam int VERTEX_POS_BITS    = CORD_WIDTH * 2 * 3; // 3 vertices x,y
   localparam int VERTEX_COLOR_BITS  = DATA_WIDTH * 3;     // 3 colors
   localparam int VERTEX_UV_BITS     = DATA_WIDTH * 2 * 3; // 3 UV pairs
-  localparam int VERTEX_TOTAL_BITS  = VERTEX_POS_BITS + VERTEX_COLOR_BITS + VERTEX_UV_BITS;
+  // Total bits for a vertex, padded to next 32-bit boundary for alignment
+  localparam int VERTEX_TOTAL_BITS_RAW = VERTEX_POS_BITS + VERTEX_COLOR_BITS + VERTEX_UV_BITS;
+  localparam int VERTEX_TOTAL_BITS = ((VERTEX_TOTAL_BITS_RAW + 31) / 32) * 32;
   localparam int FIFO_DATA_WIDTH    = (2 * CORD_WIDTH) + (3 * (2 * CORD_WIDTH + 1));
 
   // Memory map for CPU interface


### PR DESCRIPTION
Pad frame buffer address output to the next byte

Pad vertex data size to the full size as in the actual RTL

Both done for data alignment.